### PR TITLE
Refactor error handling and improve function accessibility

### DIFF
--- a/Client/IOUtils.cpp
+++ b/Client/IOUtils.cpp
@@ -18,7 +18,7 @@ std::filesystem::path readDllPath()
 	}
 	if(name.empty()) {
 		trace("Path cannot be empty");
-		throw std::runtime_error("Missing path");
+		throw std::invalid_argument("Path cannot be empty");
 	}
 	if(name.length() > 2 && name.front() == L'"' && name.back() == L'"') {
 		name = name.substr(1, name.length() - 2);
@@ -26,11 +26,11 @@ std::filesystem::path readDllPath()
 	std::filesystem::path path{name};
 	if(!std::filesystem::exists(path)) {
 		trace("File does not exist");
-		throw std::runtime_error("Invalid path");
+		throw std::invalid_argument("File does not exist");
 	}
 	if(!std::filesystem::is_regular_file(path)) {
 		trace("Path is not a regular file");
-		throw std::runtime_error("Invalid file type");
+		throw std::invalid_argument("Path is not a regular file");
 	}
 	return path;
 }

--- a/Component/Component.cpp
+++ b/Component/Component.cpp
@@ -10,7 +10,7 @@ using namespace ComponentAPI;
 
 namespace
 {
-	static void trace(const char* msg, std::source_location loc = std::source_location::current()) noexcept
+	void trace(const char* msg, std::source_location loc = std::source_location::current()) noexcept
 	{
 		try {
 			std::puts(std::format("Component 1:\t{:40} [{}:{}]", msg, loc.function_name(), loc.line()).c_str());

--- a/Component/dllmain.cpp
+++ b/Component/dllmain.cpp
@@ -1,6 +1,6 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 
-#include <windows.h>
+#include <Windows.h>
 
 BOOL APIENTRY DllMain( HMODULE /*hModule*/,
                        DWORD  ul_reason_for_call,

--- a/Interface/InterfaceWrapper.h
+++ b/Interface/InterfaceWrapper.h
@@ -30,7 +30,7 @@ public:
 	explicit InterfaceWrapper(Interface* pI):m_pI(pI)
 	{
 		if(!pI) 
-			throw std::runtime_error("Interface is not supported");
+			throw std::invalid_argument("Interface is not supported");
 	}
 	explicit InterfaceWrapper(auto p) = delete; // Prevent implicit conversion from other types
 


### PR DESCRIPTION
- Updated `readDllPath()` in `IOUtils.cpp` to throw `std::invalid_argument` for invalid path scenarios, enhancing error specificity.

- Corrected include directive in `dllmain.cpp` for Windows header to ensure compatibility on case-sensitive file systems.

- Modified exception type in `InterfaceWrapper.h` for null interface pointer from `std::runtime_error` to `std::invalid_argument` to better reflect the error nature.