### PR TITLE
Add protected destructors to ComponentAPI classes

### DIFF
--- a/Interface/details/IRandom.h
+++ b/Interface/details/IRandom.h
@@ -9,5 +9,7 @@ namespace ComponentAPI
         static constexpr auto iid = *uuids::uuid::from_string("32bb8324-b41b-11cf-a6bb-0080c7b2d682");
         virtual int32_t  GenerateRandomNumbers(size_t count, const char** numbers_json) noexcept = 0;
         virtual int32_t  FreeResult(char const* numbers_json) noexcept = 0;
+    protected:
+        ~IRandom() = default;
     };
 }

--- a/Interface/details/IUnknownRe.h
+++ b/Interface/details/IUnknownRe.h
@@ -31,5 +31,7 @@ namespace ComponentAPI
         {
             return QueryInterface(Q::iid, (IUnknownReplica**)pp);
         }
+    protected:
+        ~IUnknownReplica() = default;
     };
 }

--- a/Interface/details/IX.h
+++ b/Interface/details/IX.h
@@ -8,5 +8,7 @@ namespace ComponentAPI
     public:
         static constexpr auto iid = *uuids::uuid::from_string("32bb8320-b41b-11cf-a6bb-0080c7b2d682");
         virtual int32_t Fx(void) noexcept = 0;
+    protected:
+        ~IX() = default;
     };
 }

--- a/Interface/details/IX2.h
+++ b/Interface/details/IX2.h
@@ -9,5 +9,7 @@ namespace ComponentAPI
         static constexpr auto iid = *uuids::uuid::from_string("32bb8323-b41b-11cf-a6bb-0080c7b2d682");
         virtual int32_t GetVersion(const char** version) noexcept = 0;
         virtual int32_t FreeResult(const char* version) noexcept = 0;
+    protected:
+        ~IX2() = default;
     };
 }

--- a/Interface/details/IY.h
+++ b/Interface/details/IY.h
@@ -8,5 +8,7 @@ namespace ComponentAPI
     public:
         static constexpr auto iid = *uuids::uuid::from_string("32bb8321-b41b-11cf-a6bb-0080c7b2d682");
         virtual int32_t Fy(void) noexcept = 0;
+    protected:
+        ~IY() = default;
     };
 }


### PR DESCRIPTION
Introduce protected default destructors in the `IRandom`, `IUnknownReplica`, `IX`, `IX2`, and `IY` classes. This change prevents direct instantiation of these abstract base classes while allowing derived classes to access the destructors, promoting proper inheritance and resource management.